### PR TITLE
add view peer judging result button

### DIFF
--- a/src/pages/events/[event]/index.js
+++ b/src/pages/events/[event]/index.js
@@ -106,8 +106,8 @@ export default function Event({event}) {
                       <Button w="100%" mb={2} as="a" href={`${event.id}/notification`}>Send Notification</Button>
                       <Button w="100%" mb={2} as="a" href={`${event.id}/advancedConfig`}>Edit Advanced Config</Button>
                       <Button w="100%" mb={2} as="a" target="_blank" href={`https://showcase.codeday.org/projects/all/event=${event.id}`}>View Projects</Button>
-                      <Button w="100%" mb={2} as="a" target="_blank" href={`https://showcase.codeday.org/upload-photos`}>Upload Photos</Button>
-                    </InfoBox>
+                      <Button w="100%" mb={2} as="a" target="_blank" href={`https://showcase.codeday.org/vote/${event.id}/results`}>View Peer Judging Results</Button>
+                      <Button w="100%" mb={2} as="a" target="_blank" href={`https://showcase.codeday.org/upload-photos`}>Upload Photos</Button>                    </InfoBox>
                     <MetadataBox metadata={event.metadata}>
                       <Link href={`${event.id}/advancedConfig`}>Set metadata (advanced)</Link>
                     </MetadataBox>


### PR DESCRIPTION
There's no good way to get Peer Judging Results without having to manually create the URL (Which CodeDay Seattle has been doing for a bit now). This PR just adds a View peer judging results button to Clear to make it easier to see the results.